### PR TITLE
Fixes a bug in the link matching regex

### DIFF
--- a/src/Lexer/DefaultLexer.php
+++ b/src/Lexer/DefaultLexer.php
@@ -80,7 +80,7 @@ class DefaultLexer implements LexerInterface  {
     protected function enableElements(): void {
         if(!$this->checkFlag(self::NO_HREF)) {
             // Links
-            self::$tokens['/[^!]\[([^\]]+)\]\((?:javascript:)?([^\)]+)\)/'] = '<a href="\2">\1</a>';
+            self::$tokens['/([^!])\[([^\]]+)\]\((?:javascript:)?([^\)]+)\)/'] = '\1<a href="\3">\2</a>';
         }
 
         if(!$this->checkFlag(self::NO_IMAGES)) {


### PR DESCRIPTION
Any character (except exclamation point !) before the square bracket that starts a markdown link was excluded from the resulting HTML. Matching a non-exclamation point character is important so link syntax is not confused with image syntax, but the character matched should be preserved in the output string.